### PR TITLE
Bug fix for T1_Antecedent

### DIFF
--- a/juzzyPython/type1/system/T1_Antecedent.py
+++ b/juzzyPython/type1/system/T1_Antecedent.py
@@ -88,7 +88,7 @@ class T1_Antecedent:
             domain = self.input.getDomain().getRight() - self.input.getDomain().getLeft()
             incr = domain/(domain*50)
             x = 0
-            for i in range((domain*50)+1):
+            for i in range((int(domain)*50)+1):
                 if tNorm == 0:
                     temp = self.input.getInputMF().getFS(x)*self.getMF().getFS(x)
                 else:

--- a/juzzyPython/type1/system/T1_Antecedent.py
+++ b/juzzyPython/type1/system/T1_Antecedent.py
@@ -87,7 +87,7 @@ class T1_Antecedent:
             valxmax = 0
             domain = self.input.getDomain().getRight() - self.input.getDomain().getLeft()
             incr = domain/(domain*50)
-            x = 0
+            x = self.input.getDomain().getLeft()
             for i in range((int(domain)*50)+1):
                 if tNorm == 0:
                     temp = self.input.getInputMF().getFS(x)*self.getMF().getFS(x)


### PR DESCRIPTION
In getMax() function in T1_Antecedent.py:
1. when the domain is not int, range(domain*50)+1) will throw an error. Change this to range((int(domain)*50)+1) to avoid the error
2. Originally x is initialized to 0. But the domain of the input won't always start from 0. Initialize x to the left border of domain (`self.input.getDomain().getLeft()`)